### PR TITLE
Several fixes

### DIFF
--- a/lib/gmail.js
+++ b/lib/gmail.js
@@ -3,7 +3,7 @@ var ImapConnection = require('imap').ImapConnection,
     async = require('async'),
     EE = require('events').EventEmitter;
 
-var gm = {};
+var gm = function() {};
 exports.GMailInterface = gm;
 
 // Object class: GMailInterface
@@ -17,7 +17,7 @@ exports.GMailInterface = gm;
 // to the GMail server. 
 // 
 // The callback takes only one parameter - an error (or null if none)
-gm.connect = function(username,password,cb) {
+gm.prototype.connect = function(username,password,callback) {
   var self = this; // stupid JS 'this' binding kludge.
   self.conn = new ImapConnection({
     username: username,
@@ -30,23 +30,14 @@ gm.connect = function(username,password,cb) {
   async.series([
     function(callback){self.conn.connect(callback); },
     function(callback){self.conn.openBox('[Gmail]/All Mail',true,callback);}
-  ],
-  function(err,results) {
-    process.nextTick(function(err){return cb(err);});
-  });
+  ], callback);
 };
 
 
 // GMailInterface.logout (callback)
 // Close the active connection to GMail, ending the asynch loop.
-gm.logout = function(callback) {
-  // Some crazy bug with either the imap library or GMail means you
-  // actually can't log out. I know, right?
-  // For now, just garbage-collect the connection and hope for the best.
-  // If you get an error related to this, PLEASE post about it!
-  //self.conn.logout(callback);
-  this.conn = null;
-  callback(); // No need to be async if we aren't actually doing anything.
+gm.prototype.logout = function(callback) {
+  this.conn.logout(callback);
 }
 
 // Applys the given functon to every single email in the GMail account.
@@ -64,7 +55,7 @@ gm.logout = function(callback) {
 //                       to leave f (the applied function) as undefined.
 //  'processed'(message) - as above, but now it has been processed too.
 //  'end' - All messages have been fetched and processed.
-gm.apply_all = function(f) {
+gm.prototype.apply_all = function(f) {
   var self = this, // Stupid JS 'this' binding kludge.
       events = new EE();
   self.conn.search(['ALL'], function(err,ids) {
@@ -83,14 +74,13 @@ gm.apply_all = function(f) {
     fetched.on('message',function(msg) {
       var message = {eml:""};
       msg.on('data',function(chunk) {
-        // This line makes me queasy but I don't know better yet.
-        message.eml = message.eml + chunk.toString();
+        message.eml += chunk.toString('binary');
       })
       msg.once('end',function(){
-        message.id= msg['x-gm-msgid']; // unique across boxes, unlike msg.id
-        message.thread= msg['x-gm-thrid'];
-        message.date= msg.date;
-        message.labels= msg['x-gm-labels'];
+        message.id = msg['x-gm-msgid']; // unique across boxes, unlike msg.id
+        message.thread = msg['x-gm-thrid'];
+        message.date = msg.date;
+        message.labels = msg['x-gm-labels'];
         events.emit('fetched',message);
         if (typeof f == 'function') {
           process.nextTick(function() {

--- a/test/gmail_test.js
+++ b/test/gmail_test.js
@@ -11,7 +11,7 @@ describe('A GMailInterface object',function() {
       var settings;
       should.not.exist(err);
       settings = JSON.parse(data);
-      gm = Object.create(gmail.GMailInterface);
+      gm = new gmail.GMailInterface();
       gm.connect(settings.email,settings.password,function(err){
         should.not.exist(err);
         done();


### PR DESCRIPTION
- Export a function with a prototype
- Reinstate connection logout
- Use consistent name for callback parameter

I tested logout() and it worked just fine.
